### PR TITLE
Added files with infohashes to torrents

### DIFF
--- a/Analysis-Files/Analysis-Files-Infohashes.md
+++ b/Analysis-Files/Analysis-Files-Infohashes.md
@@ -1,11 +1,11 @@
-# Analysis-Files Infohashes Containing Compressed Files
+# Analysis-Files Infohashes To Compressed Files
 
 ## Analysis-File Infohashes
 
-| Compression Method | Magnet | Infohash Only |
-| --- | --- | --- |
-| __tar.gz__ <br> 59.3MB total | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e | 9ae22ffbc4f52236bde66a4d705fc9066380572e |
-| __7z__ <br> 46.6MB total | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b | 1633c6e525fab9c6b8a7e02aac51e69f676f746b |
+| Compression Method | Magnet <br> *Infohash Only* |
+| --- | --- | 
+| __tar.gz__ <br> 59.3MB total | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e <br> *9ae22ffbc4f52236bde66a4d705fc9066380572e* |
+| __7z__ <br> 46.6MB total | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b <br> *1633c6e525fab9c6b8a7e02aac51e69f676f746b* |
 
 __If any of these links are dead, please open an issue as soon as possible.__
 

--- a/Analysis-Files/Analysis-Files-Infohashes.md
+++ b/Analysis-Files/Analysis-Files-Infohashes.md
@@ -1,0 +1,42 @@
+# Analysis-Files Infohashes Containing Compressed Files
+
+## Analysis-File Infohashes
+
+| Compression Method | Magnet | Infohash Only |
+| --- | --- | --- |
+| __tar.gz__ <br> 59.3MB total | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e | 9ae22ffbc4f52236bde66a4d705fc9066380572e |
+| __7z__ <br> 46.6MB total | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b | 1633c6e525fab9c6b8a7e02aac51e69f676f746b |
+
+__If any of these links are dead, please open an issue as soon as possible.__
+
+
+<br>
+
+#### Recommended Unarchivers:
+* Windows: __7Zip__
+* Mac: __Keka__
+* Linux: Command Line, __p7zip__
+
+#### Recommended Torrent Client:
+* __Deluge__ gave me the best results in terms of connecting to the seedbox.
+
+
+***
+
+![Probable Wordlists Logo](https://raw.githubusercontent.com/berzerk0/Probable-Wordlists/master/ProbableWordlistLogo.png)
+
+## Disclaimer and License
+ + These lists are for LAWFUL, ETHICAL AND EDUCATIONAL PURPOSES ONLY.
+ + The files contained in this repository are released "as is" without warranty, support, or guarantee of effectiveness.
+ + *However, I am open to hearing about any issues found within these files and will be actively maintaining this repository for the foreseeable future. If you find anything noteworthy, let me know and I'll see what I can do about it.*
+
+ [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+
+ __This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)__
+
+
+<br>
+Enjoy!
+
+<br>
+This file was last updated on 4 Oct, 2023.

--- a/Dictionary-Style/Dictionary-Style-Infohashes.md
+++ b/Dictionary-Style/Dictionary-Style-Infohashes.md
@@ -1,0 +1,58 @@
+# Dictionary-Style Infohashes
+
+<br>
+
+* 2.2 GB Uncompressed
+* Max 598.2 MB Compressed
+
+Note that the BEncylcopedia is 2.0 GB of that size.
+
+These are __mostly not passwords__ and are __not sorted by probability__.
+
+
+
+You have the option to download all the files, or get them one at a time.
+
+
+  ## Dictionary-Style Infohashes
+  *Not sorted by probability, not passwords.*
+
+
+| Compression Method | Magnet | Infohash Only |
+| --- | --- | --- |
+| __tar.gz__ <br>  598.2 MB total | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e | fb05c2af37de70bbae571b247529d4edb68dd47e |
+| __7z__ <br> 468.8 MB total | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de | 877402415cceeb346afa62acc19127813477d7de |
+
+__If any of these links are dead, please open an issue as soon as possible.__
+
+
+<br>
+
+#### Recommended Unarchivers:
+* Windows: __7Zip__
+* Mac: __Keka__
+* Linux: Command Line, __p7zip__
+
+#### Recommended Torrent Client:
+* __Deluge__ gave me the best results in terms of connecting to the seedbox.
+
+
+***
+
+![Probable Wordlists Logo](https://raw.githubusercontent.com/berzerk0/Probable-Wordlists/master/ProbableWordlistLogo.png)
+
+## Disclaimer and License
+ + These lists are for LAWFUL, ETHICAL AND EDUCATIONAL PURPOSES ONLY.
+ + The files contained in this repository are released "as is" without warranty, support, or guarantee of effectiveness.
+ + *However, I am open to hearing about any issues found within these files and will be actively maintaining this repository for the foreseeable future. If you find anything noteworthy, let me know and I'll see what I can do about it.*
+
+ [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+
+ __This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)__
+
+
+<br>
+Enjoy!
+
+<br>
+This file was last updated on 4 Oct, 2023.

--- a/Dictionary-Style/Dictionary-Style-Infohashes.md
+++ b/Dictionary-Style/Dictionary-Style-Infohashes.md
@@ -18,10 +18,10 @@ You have the option to download all the files, or get them one at a time.
   *Not sorted by probability, not passwords.*
 
 
-| Compression Method | Magnet | Infohash Only |
-| --- | --- | --- |
-| __tar.gz__ <br>  598.2 MB total | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e | fb05c2af37de70bbae571b247529d4edb68dd47e |
-| __7z__ <br> 468.8 MB total | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de | 877402415cceeb346afa62acc19127813477d7de |
+| Compression Method | Magnet <br> *Infohash Only* |
+| --- | --- | 
+| __tar.gz__ <br>  598.2 MB total | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e <br> *fb05c2af37de70bbae571b247529d4edb68dd47e* |
+| __7z__ <br> 468.8 MB total | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de <br> *877402415cceeb346afa62acc19127813477d7de* |
 
 __If any of these links are dead, please open an issue as soon as possible.__
 

--- a/Downloads.md
+++ b/Downloads.md
@@ -29,6 +29,19 @@ Make sure that others have the same access to the files that you did!
 <br>
 <br>
 
+| Infohashes for torrent client|
+| --- |
+| [All files](Infohashes.md)|
+||
+| [Real-Passwords](Real-Passwords/Real-Passwords-Infohashes.md)|
+| [Real-WPA-Passwords](Real-Passwords/WPA-Length/Real-Password-WPA-Infohashes.md)|
+| [Dictionary-Style Files](Dictionary-Style/Dictionary-Style-Infohashes.md)|
+| [Analysis-Files](Analysis-Files/Analysis-Files-Infohashes.md)|
+
+
+<br>
+<br>
+
 |MegaLinks |
 | --- |
 | [Real-Passwords](Real-Passwords/Real-Passwords-MegaLinks.md)|

--- a/Infohashes.md
+++ b/Infohashes.md
@@ -14,13 +14,13 @@ Make sure that others have the same access to the files that you did!
 | --- | --- | --- | --- |
 | ProbWL-v2-Real-Passwords-7z | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 | dfbe23e4382cea3252b218f2023dea57d2357852 | 5.0 G.B |
 | ProbWL-v2-Real-Passwords-targz | magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | 8.0 GB |
-
+| --- | --- | --- | --- |
 | ProbWL-v2-Real-WPA-Passwords-7z | magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4.27 GB |
 | ProbWL-v2-Real-WPA-Passwords-targz | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd | 07143ce76b4f051980b7fc353c5743d6c17fffdd | 7.48 GB |
-
+| --- | --- | --- | --- |
 | ProbWL-v2-Dictionary-Style-7z | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de | 877402415cceeb346afa62acc19127813477d7de | 468.8 MB |
 | ProbWL-v2-Dictionary-Style-targz | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e | fb05c2af37de70bbae571b247529d4edb68dd47e | 598.2 MB|
-
+| --- | --- | --- | --- |
 | ProbWL-v2-Analysis-Files-7z | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b | 1633c6e525fab9c6b8a7e02aac51e69f676f746b | 284.2 MB |
 | ProbWL-v2-Analysis-Files-targz | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e | 9ae22ffbc4f52236bde66a4d705fc9066380572e | 416.8 MB |
 

--- a/Infohashes.md
+++ b/Infohashes.md
@@ -1,0 +1,55 @@
+#Magnet Info
+
+
+To get everything this project has to offer, you will need to download lists from links in this repository.
+
+While a few small files are available for download from within the repo, the rest can only be acquired via Torrent or Mega.NZ download.
+
+You have the ability to download all files at once, or one at a time.
+
+## Please Seed!
+Make sure that others have the same access to the files that you did!
+
+| Title | Magnet | Infohash Only | Download Size |
+| --- | --- | --- | --- |
+| ProbWL-v2-Real-Passwords-7z | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 | dfbe23e4382cea3252b218f2023dea57d2357852 | 5.0 G.B |
+| ProbWL-v2-Real-Passwords-targz | magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | 8.0 GB |
+
+| ProbWL-v2-Real-WPA-Passwords-7z | magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4.27 GB |
+| ProbWL-v2-Real-WPA-Passwords-targz | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd | 07143ce76b4f051980b7fc353c5743d6c17fffdd | 7.48 GB |
+
+| ProbWL-v2-Dictionary-Style-7z | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de | 877402415cceeb346afa62acc19127813477d7de | 468.8 MB |
+| ProbWL-v2-Dictionary-Style-targz | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e | fb05c2af37de70bbae571b247529d4edb68dd47e | 598.2 MB|
+
+| ProbWL-v2-Analysis-Files-7z | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b | 1633c6e525fab9c6b8a7e02aac51e69f676f746b | 284.2 MB |
+| ProbWL-v2-Analysis-Files-targz | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e | 9ae22ffbc4f52236bde66a4d705fc9066380572e | 416.8 MB |
+
+<br>
+
+#### Recommended Unarchivers:
+* Windows: __7Zip__
+* Mac: __Keka__
+* Linux: Command Line, __p7zip__
+
+#### Recommended Torrent Client:
+* __Deluge__ gave me the best results in terms of connecting to the seedbox.
+
+
+***
+
+![Probable Wordlists Logo](https://raw.githubusercontent.com/berzerk0/Probable-Wordlists/master/ProbableWordlistLogo.png)
+
+## Disclaimer and License
+ + These lists are for LAWFUL, ETHICAL AND EDUCATIONAL PURPOSES ONLY.
+ + The files contained in this repository are released "as is" without warranty, support, or guarantee of effectiveness.
+ + *However, I am open to hearing about any issues found within these files and will be actively maintaining this repository for the foreseeable future. If you find anything noteworthy, let me know and I'll see what I can do about it.*
+
+ [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+
+ __This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)__
+
+<br>
+Enjoy!
+
+<br>
+This file was last updated on 4 Oct, 2023.

--- a/Infohashes.md
+++ b/Infohashes.md
@@ -14,13 +14,13 @@ Make sure that others have the same access to the files that you did!
 | --- | --- | --- | --- |
 | ProbWL-v2-Real-Passwords-7z | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 | dfbe23e4382cea3252b218f2023dea57d2357852 | 5.0 G.B |
 | ProbWL-v2-Real-Passwords-targz | magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | 8.0 GB |
-| --- | --- | --- | --- |
+| | | | |
 | ProbWL-v2-Real-WPA-Passwords-7z | magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4.27 GB |
 | ProbWL-v2-Real-WPA-Passwords-targz | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd | 07143ce76b4f051980b7fc353c5743d6c17fffdd | 7.48 GB |
-| --- | --- | --- | --- |
+| | | | |
 | ProbWL-v2-Dictionary-Style-7z | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de | 877402415cceeb346afa62acc19127813477d7de | 468.8 MB |
 | ProbWL-v2-Dictionary-Style-targz | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e | fb05c2af37de70bbae571b247529d4edb68dd47e | 598.2 MB|
-| --- | --- | --- | --- |
+| | | | |
 | ProbWL-v2-Analysis-Files-7z | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b | 1633c6e525fab9c6b8a7e02aac51e69f676f746b | 284.2 MB |
 | ProbWL-v2-Analysis-Files-targz | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e | 9ae22ffbc4f52236bde66a4d705fc9066380572e | 416.8 MB |
 

--- a/Infohashes.md
+++ b/Infohashes.md
@@ -1,4 +1,4 @@
-#Magnet Info
+# Magnet Info
 
 
 To get everything this project has to offer, you will need to download lists from links in this repository.
@@ -10,19 +10,19 @@ You have the ability to download all files at once, or one at a time.
 ## Please Seed!
 Make sure that others have the same access to the files that you did!
 
-| Title | Magnet | Infohash Only | Download Size |
-| --- | --- | --- | --- |
-| ProbWL-v2-Real-Passwords-7z | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 | dfbe23e4382cea3252b218f2023dea57d2357852 | 5.0 G.B |
-| ProbWL-v2-Real-Passwords-targz | magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | 8.0 GB |
-| | | | |
-| ProbWL-v2-Real-WPA-Passwords-7z | magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4.27 GB |
-| ProbWL-v2-Real-WPA-Passwords-targz | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd | 07143ce76b4f051980b7fc353c5743d6c17fffdd | 7.48 GB |
-| | | | |
-| ProbWL-v2-Dictionary-Style-7z | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de | 877402415cceeb346afa62acc19127813477d7de | 468.8 MB |
-| ProbWL-v2-Dictionary-Style-targz | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e | fb05c2af37de70bbae571b247529d4edb68dd47e | 598.2 MB|
-| | | | |
-| ProbWL-v2-Analysis-Files-7z | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b | 1633c6e525fab9c6b8a7e02aac51e69f676f746b | 284.2 MB |
-| ProbWL-v2-Analysis-Files-targz | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e | 9ae22ffbc4f52236bde66a4d705fc9066380572e | 416.8 MB |
+| Title<br> (Format)| Magnet<br> *Infohash Only* | Download Size |
+| --- | --- | --- |
+| Real Passwords<br> (7z) | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852<br> *dfbe23e4382cea3252b218f2023dea57d2357852* | 5.0 G.B |
+| Real Passwords<br> (targz) | magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0<br> *d85c40c7f799ae1f48c8f4b891539c7b81a862f0* | 8.0 GB |
+| | | |
+| Real WPA Passwords<br> (7z) | magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0<br> *4f1007c7eb7b950c948ad49772504bb5f49121f0* | 4.27 GB |
+| Real WPA Passwords<br> (targz) | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd<br> *07143ce76b4f051980b7fc353c5743d6c17fffdd* | 7.48 GB |
+| | | |
+| Dictionary Style<br> (7z) | magnet:?xt=urn:btih:877402415cceeb346afa62acc19127813477d7de<br> *877402415cceeb346afa62acc19127813477d7de* | 468.8 MB |
+| Dictionary Style<br> (targz) | magnet:?xt=urn:btih:fb05c2af37de70bbae571b247529d4edb68dd47e<br> *fb05c2af37de70bbae571b247529d4edb68dd47e* | 598.2 MB|
+| | | |
+| Analysis Files<br> (7z) | magnet:?xt=urn:btih:1633c6e525fab9c6b8a7e02aac51e69f676f746b<br> *1633c6e525fab9c6b8a7e02aac51e69f676f746b* | 284.2 MB |
+| Analysis Files<br> (targz) | magnet:?xt=urn:btih:9ae22ffbc4f52236bde66a4d705fc9066380572e<br> *9ae22ffbc4f52236bde66a4d705fc9066380572e* | 416.8 MB |
 
 <br>
 

--- a/Real-Passwords/Real-Passwords-Infohashes.md
+++ b/Real-Passwords/Real-Passwords-Infohashes.md
@@ -1,4 +1,4 @@
-# Real-Password Infohashes Containing Compressed Files
+# Real-Password Infohashes To Compressed Files
 Contains all the passwords, but __*no*__ files exclusively containing __*WPA-Length*__ lines.
 
 
@@ -11,10 +11,10 @@ Contains all the passwords, but __*no*__ files exclusively containing __*WPA-Len
 ## Real-Password Infohashes
 *No files linked here are exclusively WPA-Length*
 
-| Compression Method | Magnet | Infohash Only |
-| --- | --- | --- |
-| __tar.gz__ <br> 8.0 GB total |  magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | d85c40c7f799ae1f48c8f4b891539c7b81a862f0 |
-| __7z__ <br> 5.0 GB total | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 | dfbe23e4382cea3252b218f2023dea57d2357852 |
+| Compression Method | Magnet <br> *Infohash Only* |
+| --- | --- |
+| __tar.gz__ <br> 8.0 GB total |  magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 <br> *d85c40c7f799ae1f48c8f4b891539c7b81a862f0* |
+| __7z__ <br> 5.0 GB total | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 <br> *dfbe23e4382cea3252b218f2023dea57d2357852* |
 
 __If any of these links are dead, please open an issue as soon as possible with the URL included__
 

--- a/Real-Passwords/Real-Passwords-Infohashes.md
+++ b/Real-Passwords/Real-Passwords-Infohashes.md
@@ -1,0 +1,51 @@
+# Real-Password Infohashes Containing Compressed Files
+Contains all the passwords, but __*no*__ files exclusively containing __*WPA-Length*__ lines.
+
+
+* 27 GB Uncompressed
+* Max 8 GB Compressed
+
+ You have the option to download all the files, or get them one at a time.
+
+
+## Real-Password Infohashes
+*No files linked here are exclusively WPA-Length*
+
+| Compression Method | Magnet | Infohash Only |
+| --- | --- | --- |
+| __tar.gz__ <br> 8.0 GB total |  magnet:?xt=urn:btih:d85c40c7f799ae1f48c8f4b891539c7b81a862f0 | d85c40c7f799ae1f48c8f4b891539c7b81a862f0 |
+| __7z__ <br> 5.0 GB total | magnet:?xt=urn:btih:dfbe23e4382cea3252b218f2023dea57d2357852 | dfbe23e4382cea3252b218f2023dea57d2357852 |
+
+__If any of these links are dead, please open an issue as soon as possible with the URL included__
+
+
+<br>
+
+#### Recommended Unarchivers:
+* Windows: __7Zip__
+* Mac: __Keka__
+* Linux: Command Line, __p7zip__
+
+#### Recommended Torrent Client:
+* __Deluge__ gave me the best results in terms of connecting to the seedbox.
+
+
+***
+
+![Probable Wordlists Logo](https://raw.githubusercontent.com/berzerk0/Probable-Wordlists/master/ProbableWordlistLogo.png)
+
+## Disclaimer and License
+ + These lists are for LAWFUL, ETHICAL AND EDUCATIONAL PURPOSES ONLY.
+ + The files contained in this repository are released "as is" without warranty, support, or guarantee of effectiveness.
+ + *However, I am open to hearing about any issues found within these files and will be actively maintaining this repository for the foreseeable future. If you find anything noteworthy, let me know and I'll see what I can do about it.*
+
+ [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+
+ __This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)__
+
+
+<br>
+Enjoy!
+
+<br>
+This file was last updated on 4 Oct, 2023.

--- a/Real-Passwords/WPA-Length/Real-Password-WPA-Infohashes.md
+++ b/Real-Passwords/WPA-Length/Real-Password-WPA-Infohashes.md
@@ -1,4 +1,4 @@
-# Real-Password Infohashes Containing Compressed WPA-Length Files
+# Real-Password Infohashes To Compressed WPA-Length Files
 
 
 All files are composed of __*exclusively WPA-Length*__ lines.
@@ -14,10 +14,10 @@ You have the option to download all the files, or get them one at a time.
   *Exclusively WPA-Length*
 
 
-| Compression Method | Magnet | Infohash Only |
-| --- | --- | --- |
-| __tar.gz__ <br> 7.48 GB total | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd | 07143ce76b4f051980b7fc353c5743d6c17fffdd |
-| __7z__ <br> 4.27 GB total |magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4f1007c7eb7b950c948ad49772504bb5f49121f0 |
+| Compression Method | Magnet <br> *Infohash Only* |
+| --- | --- | 
+| __tar.gz__ <br> 7.48 GB total | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd <br> *07143ce76b4f051980b7fc353c5743d6c17fffdd* |
+| __7z__ <br> 4.27 GB total |magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 <br> *4f1007c7eb7b950c948ad49772504bb5f49121f0* |
 
 __If any of these links are dead, please open an issue as soon as possible.__
 

--- a/Real-Passwords/WPA-Length/Real-Password-WPA-Infohashes.md
+++ b/Real-Passwords/WPA-Length/Real-Password-WPA-Infohashes.md
@@ -1,0 +1,52 @@
+# Real-Password Infohashes Containing Compressed WPA-Length Files
+
+
+All files are composed of __*exclusively WPA-Length*__ lines.
+
+* 25.3 GB Uncompressed
+* Max 7.48 GB Compressed
+
+
+You have the option to download all the files, or get them one at a time.
+
+
+  ## Real-WPA-Password Infohashes
+  *Exclusively WPA-Length*
+
+
+| Compression Method | Magnet | Infohash Only |
+| --- | --- | --- |
+| __tar.gz__ <br> 7.48 GB total | magnet:?xt=urn:btih:07143ce76b4f051980b7fc353c5743d6c17fffdd | 07143ce76b4f051980b7fc353c5743d6c17fffdd |
+| __7z__ <br> 4.27 GB total |magnet:?xt=urn:btih:4f1007c7eb7b950c948ad49772504bb5f49121f0 | 4f1007c7eb7b950c948ad49772504bb5f49121f0 |
+
+__If any of these links are dead, please open an issue as soon as possible.__
+
+
+#### Recommended Unarchivers:
+* Windows: __7Zip__
+* Mac: __Keka__
+* Linux: Command Line, __p7zip__
+
+#### Recommended Torrent Client:
+* __Deluge__ gave me the best results in terms of connecting to the seedbox.
+
+
+***
+
+![Probable Wordlists Logo](https://raw.githubusercontent.com/berzerk0/Probable-Wordlists/master/ProbableWordlistLogo.png)
+
+## Disclaimer and License
+ + These lists are for LAWFUL, ETHICAL AND EDUCATIONAL PURPOSES ONLY.
+ + The files contained in this repository are released "as is" without warranty, support, or guarantee of effectiveness.
+ + *However, I am open to hearing about any issues found within these files and will be actively maintaining this repository for the foreseeable future. If you find anything noteworthy, let me know and I'll see what I can do about it.*
+
+ [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](http://creativecommons.org/licenses/by-sa/4.0/)
+
+ __This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)__
+
+
+<br>
+Enjoy!
+
+<br>
+This file was last updated on 4 Oct, 2023.


### PR DESCRIPTION
Suggesting an option for users to add the torrents by infohash rather than by downloading .torrent files.